### PR TITLE
#50 Fix various search issues

### DIFF
--- a/resources/db/applications.sql
+++ b/resources/db/applications.sql
@@ -52,7 +52,7 @@ SELECT a_id,
              AND a_last_modified >= COALESCE(:modified_after, a_last_modified)
              AND a_team_id = COALESCE(:team_id, a_team_id)
              AND a_active = COALESCE(:active, a_active)) as apps,
-                 plainto_tsquery('english', coalesce(:searchquery, '')) query
+                 plainto_tsquery('english', COALESCE(:searchquery, '')) query
    WHERE query @@ vector
 ORDER BY a_matched_rank DESC;
 

--- a/resources/db/applications.sql
+++ b/resources/db/applications.sql
@@ -49,7 +49,7 @@ SELECT a_id,
              AND a_last_modified >= COALESCE(:modified_after, a_last_modified)
              AND a_team_id = COALESCE(:team_id, a_team_id)
              AND a_active = COALESCE(:active, a_active)) as apps,
-                 plainto_tsquery('english', :searchquery) query
+                 plainto_tsquery('english', coalesce(:searchquery, '')) query
    WHERE query @@ vector
 ORDER BY a_matched_rank DESC;
 

--- a/resources/db/applications.sql
+++ b/resources/db/applications.sql
@@ -27,7 +27,10 @@ SELECT a_id,
          a_specification_url,
          a_last_modified,
          ts_rank_cd(vector, query) AS a_matched_rank,
-         ts_headline('english', a_id || a_name || COALESCE(a_subtitle, '') || COALESCE(a_description, ''), query) AS a_matched_description
+         ts_headline('english', a_id || ' ' ||
+                                a_name || ' ' ||
+                                COALESCE(a_subtitle, '') || ' ' ||
+                                COALESCE(a_description, ''), query) AS a_matched_description
     FROM (SELECT a_id,
                  a_team_id,
                  a_active,

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -91,11 +91,7 @@
   [{:keys [search modified_before modified_after team_id active]} request db]
   (u/require-realms #{"employees" "services"} request)
   (let [conn {:connection db}
-        params {:searchquery    (when search
-                                  (-> search
-                                      str/trim
-                                      (str/replace #" " "|")
-                                      (str/replace #"\|+" " | ")))
+        params {:searchquery search
                 :team_id team_id
                 :active active
                 :modified_before (tcoerce/to-sql-time modified_before)

--- a/test/org/zalando/stups/kio/api_test.clj
+++ b/test/org/zalando/stups/kio/api_test.clj
@@ -69,49 +69,6 @@
                                       (get :http-code)
                                       (= 403))))))))
 
-(deftest test-search
-
-  (testing "it should trim the search and replace any whitespaces in between with a pipe"
-    (let [calls (atom {})
-          params {:search "  this     is  a search   "}]
-      (with-redefs [fuser/require-realms (constantly nil)
-                    sql/cmd-search-applications (util/track calls :search)]
-        (api/read-applications params nil nil)
-        (util/same! 1 (count (:search @calls)))
-        (util/same! "this | is | a | search"
-                    (-> @calls
-                        :search
-                        ; first call
-                        first
-                        ; first argument = parameters
-                        first
-                        ; search param
-                        :searchquery)))))
-
-  (testing "it should not affect queries without searches"
-    (with-redefs [fuser/require-realms (constantly nil)
-                  sql/cmd-read-applications (constantly nil)
-                  sql/cmd-search-applications (constantly nil)]
-        ; succeeds when it doesn't throw
-        (api/read-applications {} nil nil)))
-
-  (testing "it should not affect queries without whitespace"
-    (let [calls (atom {})
-          params {:search "alsoasearch"}]
-      (with-redefs [fuser/require-realms (constantly nil)
-                    sql/cmd-search-applications (util/track calls :search)]
-        (api/read-applications params nil nil)
-        (util/same! 1 (count (:search @calls)))
-        (util/same! "alsoasearch"
-                    (-> @calls
-                        :search
-                        ; first call
-                        first
-                        ; first argument = parameters
-                        first
-                        ; search param
-                        :searchquery))))))
-
 (deftest test-read-access
 
   (testing "people without a team should read applications"


### PR DESCRIPTION
Fixes #48, #50 
- Use english dictionary. Most of the text in the db and also searches are in English. This dictionary maps tokens to english lexemes e.g. `management` => `manag` whereas the simple dictionary doesn't (`management` => `management`), which leads to searches like `management` only matching exactly.
- Use `plainto_tsquery` which strips punctuation and inserts `&` operators instead
- Search in application id as well, it's weird to not find apps by id
- `a_matched_description` contained only matches in the description which could lead to an app be found due to a match in the subtitle and `a_matched_description` being empty. It now contains any match.
