### PR TITLE
Validate versions properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: clojure
+services:
+  - postgresql
+before_script:
+  - psql -c 'create database kio;' -U postgres
 script:
   - lein clean
   - lein test

--- a/resources/api/kio-api.yaml
+++ b/resources/api/kio-api.yaml
@@ -486,8 +486,7 @@ parameters:
     type: string
     description: ID of the version
     required: true
-    pattern: "^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$"
-    #example: "1.0"
+    pattern: "^[A-Za-z0-9]+([._-][A-Za-z0-9]+)*$"
 
 responses:
   Error:


### PR DESCRIPTION
Currently KIO accepts versions like `1...0` and `0...---...0`.

I think it is not good and we should validate the versions properly. This PR changes the regex that we use to validate. Although I am not sure if that is a feature or a bug. Just in case, there you have a PR so we can discuss.
