### PR TITLE
use latest OpenJDK for MEM_TOTAL_KB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/stups/openjdk:8-42
+FROM registry.opensource.zalan.do/stups/openjdk:latest
 
 MAINTAINER Zalando SE
 


### PR DESCRIPTION
Update OpenJDK to support setting Kubernetes memory limit.