### PR TITLE
Use strings to name tokens for compatibility with secret files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,8 +8,8 @@
   :min-lein-version "2.0.0"
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.zalando.stups/friboo "1.10.0"]
-                 [clj-time "0.12.0"]
+                 [org.zalando.stups/friboo "1.13.0"]
+                 [clj-time "0.13.0"]
                  [org.zalando.stups/tokens "0.11.0-beta-2"]
                  [yesql "0.5.3"]]
 
@@ -53,4 +53,4 @@
                        :source-paths ["dev"]
                        :dependencies [[org.clojure/tools.namespace "0.2.10"]
                                       [midje "1.8.3"]
-                                      [org.clojure/java.classpath "0.2.2"]]}})
+                                      [org.clojure/java.classpath "0.2.3"]]}})

--- a/src/org/zalando/stups/kio/core.clj
+++ b/src/org/zalando/stups/kio/core.clj
@@ -36,10 +36,11 @@
                         api/map->API [:db :http-audit-logger]
                         :db (sql/map->DB {:configuration (:db configuration)})
                         :http-audit-logger (using
-                                             (http-logger/map->HTTP {:configuration (:httplogger configuration)})
-                                             [:tokens])
-                        :tokens (o2/map->OAUth2TokenRefresher {:configuration (:oauth2 configuration)
-                                                               :tokens        {:http-audit-logger ["uid"]}}))]
+                                            (http-logger/map->HTTP {:configuration (assoc (:httplogger configuration)
+                                                                                          :token-name "http-audit-logger")})
+                                            [:tokens])
+                        :tokens (o2/map->OAuth2TokenRefresher {:configuration (:oauth2 configuration)
+                                                               :tokens        {"http-audit-logger" ["uid"]}}))]
 
     (system/run configuration system)))
 

--- a/test/org/zalando/stups/kio/integration_test/api_test.clj
+++ b/test/org/zalando/stups/kio/integration_test/api_test.clj
@@ -21,7 +21,7 @@
 
 (deftest ^:integration integration-test
   (with-redefs [api/require-write-authorization (constantly nil)
-                oauth2/map->OAUth2TokenRefresher map->NoTokenRefresher
+                oauth2/map->OAuth2TokenRefresher map->NoTokenRefresher
                 oauth2/access-token (constantly "token")
                 api/from-token (constantly "barfoo")]
 


### PR DESCRIPTION
This is to enable use of the secret file mechanism in our Kubernetes clusters.
Also, we update some dependencies.