### PR TITLE
Run unit tests and Build in CDP

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -10,4 +10,4 @@ approvals:
   # This will probably become the default in zappr.
   ignore: none
   
-X-Zalando-Team: "torch"
+X-Zalando-Team: "automata"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -19,6 +19,7 @@ build_steps:
 - desc: Build and push docker image
   cmd: |
     lein do clean, uberjar
+    touch scm-source.json # TODO Remove this after removing it from Dockerfile
     IMAGE="pierone.stups.zalan.do/automata/kio:${CDP_BUILD_VERSION}"
     docker build -t "$IMAGE" .
     if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -19,7 +19,7 @@ build_steps:
 - desc: Build and push docker image
   cmd: |
     lein do clean, uberjar
-    touch scm-source.json # TODO Remove this after removing it from Dockerfile
+    touch target/scm-source.json # TODO Remove this after removing it from Dockerfile
     IMAGE="pierone.stups.zalan.do/automata/kio:${CDP_BUILD_VERSION}"
     docker build -t "$IMAGE" .
     if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -16,3 +16,14 @@ build_steps:
   cmd: |
     docker run -d -p 5432:5432 postgres
     lein test
+- desc: Build and push docker image
+  cmd: |
+    lein do clean, uberjar
+    IMAGE="pierone.stups.zalan.do/automata/kio:${CDP_BUILD_VERSION}"
+    docker build -t "$IMAGE" .
+    if [ -z "$CDP_PULL_REQUEST_NUMBER" ]; then
+      docker push "$IMAGE"
+    fi
+    TEST_IMAGE="pierone.stups.zalan.do/automata/kio-test:${CDP_BUILD_VERSION}"
+    docker tag "$IMAGE" "$TEST_IMAGE"
+    docker push "$TEST_IMAGE"

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,0 +1,18 @@
+build_meta:
+  env:
+    LEIN_ROOT: true
+build_steps:
+- desc: Install dependencies
+  cmd: |
+    # OpenJDK
+    apt-get update
+    apt-get install -y openjdk-8*
+    # Leiningen
+    curl https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein >/usr/bin/lein
+    chmod a+x /usr/bin/lein
+    # Docker
+    curl -fsSL https://delivery.cloud.zalando.com/utils/ensure-docker | sh
+- desc: Run unit tests
+  cmd: |
+    docker run -d -p 5432:5432 postgres
+    lein cloverage

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -15,4 +15,4 @@ build_steps:
 - desc: Run unit tests
   cmd: |
     docker run -d -p 5432:5432 postgres
-    lein cloverage
+    lein test


### PR DESCRIPTION
- Run unit tests in CDP;
- Build and push docker images with CDP;
- Change owner team in Zappr;

(The CDP job is failing because of docker push failing due to the team change).