### PR TITLE
fix: put api specification into the /zalando-apis directory (#94)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Zalando SE
 
 RUN mkdir /appdynamics
 COPY appdynamics /appdynamics
-COPY resources/api/kio-api.yaml /zalando-apis
+COPY resources/api/kio-api.yaml /zalando-apis/
 
 EXPOSE 8080
 ENV HTTP_PORT=8080


### PR DESCRIPTION
Related to #94 