### PR TITLE
Add field "incident_contact"

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,11 +7,14 @@
 
   :min-lein-version "2.0.0"
 
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.zalando.stups/friboo "1.13.0"]
                  [clj-time "0.13.0"]
                  [org.zalando.stups/tokens "0.11.0-beta-2"]
                  [yesql "0.5.3"]]
+
+  :managed-dependencies [[org.flatland/ordered "1.5.7"]
+                         [marick/suchwow "6.0.2"]]
 
   :main ^:skip-aot org.zalando.stups.kio.core
   :uberjar-name "kio.jar"
@@ -52,5 +55,5 @@
              :dev     {:repl-options {:init-ns user}
                        :source-paths ["dev"]
                        :dependencies [[org.clojure/tools.namespace "0.2.10"]
-                                      [midje "1.8.3"]
+                                      [midje "1.9.8"]
                                       [org.clojure/java.classpath "0.2.3"]]}})

--- a/resources/api/kio-api.yaml
+++ b/resources/api/kio-api.yaml
@@ -63,6 +63,11 @@ paths:
           description: "Only include apps of this team"
           type: string
           required: false
+        - name: incident_contact
+          in: query
+          description: "Only include apps with 24x7 support by the given contact/team"
+          type: string
+          required: false
         - name: active
           in: query
           description: "If true, include only active apps"

--- a/resources/api/kio-api.yaml
+++ b/resources/api/kio-api.yaml
@@ -84,6 +84,10 @@ paths:
                   type: string
                   description: ID of the team, responsible for this application
                   example: stups
+                incident_contact:
+                  type: string
+                  description: 24x7 contact, e.g. team ID of on-call support team
+                  example: sre
                 active:
                   type: boolean
                   description: If this appliation is active, ie gets credentials
@@ -154,6 +158,10 @@ paths:
                 type: string
                 description: ID of the team, responsible for this application
                 example: stups
+              incident_contact:
+                type: string
+                description: 24x7 contact, e.g. team ID of on-call support team
+                example: sre
               active:
                 type: boolean
                 description: If the application is active
@@ -514,6 +522,10 @@ definitions:
         type: string
         description: ID of the team, responsible for this application
         example: stups
+      incident_contact:
+        type: string
+        description: 24x7 contact, e.g. team ID of on-call support team
+        example: sre
       active:
         type: boolean
         description: if the application is active

--- a/resources/db/applications.sql
+++ b/resources/db/applications.sql
@@ -1,6 +1,7 @@
 -- name: read-applications
 SELECT a_id,
        a_team_id,
+       a_incident_contact,
        a_active,
        a_name,
        a_subtitle,
@@ -13,11 +14,13 @@ SELECT a_id,
  WHERE a_last_modified <= COALESCE(:modified_before, a_last_modified)
    AND a_last_modified >= COALESCE(:modified_after, a_last_modified)
    AND a_active = COALESCE(:active, a_active)
-   AND a_team_id = COALESCE(:team_id, a_team_id);
+   AND a_team_id = COALESCE(:team_id, a_team_id)
+   AND a_incident_contact = COALESCE(:incident_contact, a_incident_contact);
 
 -- name: search-applications
   SELECT a_id,
          a_team_id,
+         a_incident_contact,
          a_active,
          a_name,
          a_subtitle,
@@ -33,6 +36,7 @@ SELECT a_id,
                                 COALESCE(a_description, ''), query) AS a_matched_description
     FROM (SELECT a_id,
                  a_team_id,
+                 a_incident_contact,
                  a_active,
                  a_name,
                  a_subtitle,
@@ -51,6 +55,7 @@ SELECT a_id,
            WHERE a_last_modified <= COALESCE(:modified_before, a_last_modified)
              AND a_last_modified >= COALESCE(:modified_after, a_last_modified)
              AND a_team_id = COALESCE(:team_id, a_team_id)
+             AND a_incident_contact = COALESCE(:incident_contact, a_incident_contact)
              AND a_active = COALESCE(:active, a_active)) as apps,
                  plainto_tsquery('english', COALESCE(:searchquery, '')) query
    WHERE query @@ vector
@@ -59,6 +64,7 @@ ORDER BY a_matched_rank DESC;
 --name: read-application
 SELECT a_id,
        a_team_id,
+       a_incident_contact,
        a_active,
        a_name,
        a_subtitle,
@@ -81,6 +87,7 @@ SELECT a_id,
 WITH application_update AS (
      UPDATE zk_data.application
         SET a_team_id             = :team_id,
+            a_incident_contact    = :incident_contact,
             a_active              = :active,
             a_name                = :name,
             a_subtitle            = :subtitle,
@@ -99,6 +106,7 @@ WITH application_update AS (
 INSERT INTO zk_data.application (
             a_id,
             a_team_id,
+            a_incident_contact,
             a_active,
             a_name,
             a_subtitle,
@@ -114,6 +122,7 @@ INSERT INTO zk_data.application (
             a_criticality_level)
      SELECT :id,
             :team_id,
+            :incident_contact,
             :active,
             :name,
             :subtitle,

--- a/resources/db/migration/V8__Add_incident_contact_field.sql
+++ b/resources/db/migration/V8__Add_incident_contact_field.sql
@@ -1,0 +1,4 @@
+-- adds a new column, without locking the table.
+
+ALTER TABLE zk_data.application
+ ADD COLUMN a_incident_contact TEXT;

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -85,11 +85,12 @@
 ;; applications
 
 (defn read-applications
-  [{:keys [search modified_before modified_after team_id active]} request {:keys [db]}]
+  [{:keys [search modified_before modified_after team_id incident_contact active]} request {:keys [db]}]
   (u/require-realms #{"employees" "services"} request)
   (let [conn {:connection db}
         params {:searchquery search
                 :team_id team_id
+                :incident_contact incident_contact
                 :active active
                 :modified_before (tcoerce/to-sql-time modified_before)
                 :modified_after  (tcoerce/to-sql-time modified_after)}]
@@ -139,7 +140,8 @@
 
 (defn create-or-update-application! [{:keys [application application_id]} request {:keys [db http-audit-logger]}]
   (let [uid (from-token request "uid")
-        defaults {:specification_url   nil
+        defaults {:incident_contact    nil
+                  :specification_url   nil
                   :documentation_url   nil
                   :subtitle            nil
                   :scm_url             nil


### PR DESCRIPTION
Fixes #99:

* add new field `incident_contact` ("24x7 contact", type TEXT, nullable) to the `applications` table
* expose the field as optional in the API for read/write
* allow searching applications by this field (query parameter `incident_contact`)