### PR TITLE
if new team id, check if it exists

### DIFF
--- a/test/org/zalando/stups/kio/unit_test/api_test.clj
+++ b/test/org/zalando/stups/kio/unit_test/api_test.clj
@@ -77,6 +77,7 @@
                                            "realm" "/employees"}}
         (api/load-application .app-id. .db.) => {:team_id .db-team-id.}
         (sql/cmd-create-or-update-application! anything {:connection .db.}) => nil
+        (api/team-exists? .request. .api-team-id.) => true
         (api/require-write-authorization .request. .db-team-id.) => nil))
 
     (fact "when creating application, the team in body is compared"
@@ -91,6 +92,7 @@
                                            "realm" "/employees"}}
         (api/load-application .app-id. .db.) => nil
         (sql/cmd-create-or-update-application! anything {:connection .db.}) => nil
+        (api/team-exists? .request. .api-team-id.) => true
         (api/require-write-authorization .request. .api-team-id.) => nil))))
 
 (deftest ^:unit test-require-write-access


### PR DESCRIPTION
Part of: https://github.bus.zalan.do/automata/issues/issues/2440
It should not be possible to assign an app to non-existing team.