### PR TITLE
Fix active state toggle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ script:
   - lein clean
   - lein test
   - lein uberjar
+dist: trusty  # https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/8
 jdk:
   - oraclejdk8

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -157,12 +157,6 @@
           status          (:status response)]
       (= 200 status))))
 
-(defn merge-app-fields [old-fields new-fields]
-  {:pre  [(map? old-fields)
-          (map? new-fields)]
-   :post [(map? %)]}
-  (merge old-fields new-fields))
-
 (defn default-fields [creator-user-id]
   {:incident_contact    nil
    :specification_url   nil
@@ -195,7 +189,7 @@
   (let [old-app       (or old-app (default-fields user-id))
         new-app       (into {} (filter value-not-nil? new-app))
         app-id        (or (:id old-app) (:id new-app))
-        merged-fields (merge-app-fields old-app new-app)]
+        merged-fields (merge old-app new-app)]
     (assoc merged-fields
       :id app-id
       :last_modified_by user-id)))

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -176,8 +176,11 @@
    :criticality_level   2
    :created_by          uid})
 
+(defn- value-not-nil? [[_ v]] (some? v))
+
 (defn created-or-updated-app [old-app new-app user-id]
   {:pre  [(map? new-app)
+          (every? value-not-nil? new-app)
           (if (nil? old-app)
             (contains? new-app :id)
             (and (map? old-app)
@@ -196,7 +199,8 @@
   (let [uid                  (from-token request "uid")
         existing_application (load-application application_id db)
         existing_team_id     (:team_id existing_application)
-        team_id              (:team_id application)]
+        team_id              (:team_id application)
+        application          (into {} (filter value-not-nil? application))]
 
     (if (nil? existing_application)
       (require-write-authorization request team_id)

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -162,7 +162,7 @@
           (map? new-fields)]
    :post [(map? %)
           (seq %)]}
-  (merge-with #(or %2 %1) old-fields new-fields))
+  (merge old-fields new-fields))
 
 (defn default-fields [uid]
   {:incident_contact    nil

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -163,7 +163,7 @@
    :post [(map? %)]}
   (merge old-fields new-fields))
 
-(defn default-fields [uid]
+(defn default-fields [creator-user-id]
   {:incident_contact    nil
    :specification_url   nil
    :documentation_url   nil
@@ -174,7 +174,7 @@
    :specification_type  nil
    :publicly_accessible false
    :criticality_level   2
-   :created_by          uid})
+   :created_by          creator-user-id})
 
 (defn- value-not-nil? [[_ v]] (some? v))
 

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -160,8 +160,7 @@
 (defn merge-app-fields [old-fields new-fields]
   {:pre  [(map? old-fields)
           (map? new-fields)]
-   :post [(map? %)
-          (seq %)]}
+   :post [(map? %)]}
   (merge old-fields new-fields))
 
 (defn default-fields [uid]

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -182,7 +182,7 @@
             (contains? new-app :id)
             (and (map? old-app)
                  (contains? old-app :id)))
-          (seq (name user-id))]
+          (not (clojure.string/blank? user-id))]
    :post [(map? %)
           (seq %)
           (= (:last_modified_by %) user-id)

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -194,8 +194,11 @@
                   (select-keys % (keys new-app)))]}
   (let [old-app       (or old-app (default-fields user-id))
         new-app       (into {} (filter value-not-nil? new-app))
+        app-id        (or (:id old-app) (:id new-app))
         merged-fields (merge-app-fields old-app new-app)]
-    (assoc merged-fields :last_modified_by user-id)))
+    (assoc merged-fields
+      :id app-id
+      :last_modified_by user-id)))
 
 (defn create-or-update-application! [{:keys [application application_id]} request {:keys [db http-audit-logger]}]
   (let [uid                  (from-token request "uid")

--- a/test/org/zalando/stups/kio/unit_test/api_test.clj
+++ b/test/org/zalando/stups/kio/unit_test/api_test.clj
@@ -71,11 +71,12 @@
         .logger. =contains=> {:log-fn identity}
         .params. =contains=> {:application_id .app-id.
                               :application    {:team_id .api-team-id.
+                                               :id .app-id.
                                                :active  true
                                                :name    "test"}}
         .request. =contains=> {:tokeninfo {"uid"   "nikolaus"
                                            "realm" "/employees"}}
-        (api/load-application .app-id. .db.) => {:team_id .db-team-id.}
+        (api/load-application .app-id. .db.) => {:team_id .db-team-id. :id .app-id.}
         (sql/cmd-create-or-update-application! anything {:connection .db.}) => nil
         (api/team-exists? .request. .api-team-id.) => true
         (api/require-write-authorization .request. .db-team-id.) => nil))
@@ -85,15 +86,16 @@
       (provided
         .logger. =contains=> {:log-fn identity}
         .params. =contains=> {:application_id .app-id.
-                              :application    {:team_id "team-team"
+                              :application    {:team_id .api-team-id.
+                                               :id .app-id.
                                                :active  true
                                                :name    "test"}}
         .request. =contains=> {:tokeninfo {"uid"   "nikolaus"
                                            "realm" "/employees"}}
         (api/load-application .app-id. .db.) => nil
         (sql/cmd-create-or-update-application! anything {:connection .db.}) => nil
-        (api/team-exists? .request. "team-team") => true
-        (api/require-write-authorization .request. "team-team") => nil))
+        (api/team-exists? .request. .api-team-id.) => true
+        (api/require-write-authorization .request. .api-team-id.) => nil))
 
     (fact "when creating/updating application, the team is checked"
       (api/create-or-update-application! .params. .request. {:db .db. :http-audit-logger .logger.}) => (throws Exception)
@@ -101,7 +103,7 @@
         .logger. =contains=> {:log-fn identity}
         .params. =contains=> {:application_id .app-id.
                               :application    {:team_id nil
-                                               :id "test"
+                                               :id .app-id.
                                                :active  true
                                                :name    "test"}}
         .request. =contains=> {:tokeninfo {"uid"   "nikolaus"
@@ -114,7 +116,7 @@
         .logger. =contains=> {:log-fn identity}
         .params. =contains=> {:application_id .app-id.
                               :application    {:team_id " "
-                                               :id "test"
+                                               :id .app-id.
                                                :active  true
                                                :name    "test"}}
         .request. =contains=> {:configuration {:magnificent-url .magnificent-url.}

--- a/test/org/zalando/stups/kio/unit_test/api_test.clj
+++ b/test/org/zalando/stups/kio/unit_test/api_test.clj
@@ -275,9 +275,22 @@
         (api/load-application .application-id. .db.) => {:team_id .team-id.
                                                          :id      .application-id.})))))
 
-(t/deftest ^:unit merge-app-fields
-  (t/testing "can toggle the active status"
-    (t/is (= {:active false}
-             (api/merge-app-fields {:active true} {:active false})))
-    (t/is (= {:active true}
-             (api/merge-app-fields {:active false} {:active true})))))
+(t/deftest ^:unit created-or-updated-app
+  (t/is (= {:id "x" :a nil :b 2 :c 3 :last_modified_by "bob"}
+           (api/created-or-updated-app {:id "x" :a nil :b 2} {:b nil :c 3} "bob"))
+        "should not update fields to nil")
+  (t/is (= {:id "x" :a true :b false :c true :d false :last_modified_by "bob"}
+           (api/created-or-updated-app {:id "x" :a false :b true :c true :d false}
+                                       {:id "x" :a true :b false}
+                                       "bob"))
+        "boolean fields should be updated to match their value in new-app")
+  (t/is (= {:id "x" :a 1 :last_modified_by "bar"}
+           (api/created-or-updated-app {:id "x" :last_modified_by "foo"}
+                                       {:a 1}
+                                       "bar"))
+        ":last_modified_by should be updated")
+  (t/is (= {:id "x" :a 1 :b 2 :last_modified_by "bob"}
+           (api/created-or-updated-app {:id "x" :a 1}
+                                       {:id "y" :b 2}
+                                       "bob"))
+        ":id should never be updated"))


### PR DESCRIPTION
Make it possible again to toggle the state of an application from "active" to "inactive".

![Screenshot from 2019-09-24T14-25-49](https://user-images.githubusercontent.com/968838/65589105-d1ce1100-df88-11e9-8993-7fcd0a873d31.png)

Previously, the use of `(merge-with #(or %2 %1))` meant that "updating" a boolean field would simply set that field to _true_ as long as the old or new field was _true_ (truth table of `or`). Replacing that with a simple `(merge)` solves the problem, as long as there can't be new `nil` fields.

To be able to write unit tests for that use-case, most of the changes in this PR are just extraction of existing features from `create-or-update-application!` into pure functions.