### PR TITLE
remove postcondition over nil fields

### DIFF
--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -181,9 +181,7 @@
           (= (:last_modified_by %) user-id)
           (or (some? old-app)
               (= (:created_by %) user-id))
-          (= (:id %) app-id)
-          (every? value-not-nil?                            ;; no new field is set to nil
-                  (select-keys % (keys new-app)))]}
+          (= (:id %) app-id)]}
   (let [old-app       (or old-app (default-fields user-id))
         new-app       (into {} (filter value-not-nil? new-app))
         merged-fields (merge old-app new-app)]


### PR DESCRIPTION
My Clojure is not good enough for me to come up with a short, efficient way to check "the resulting fields are never nil, unless they were already nil before" that would be appropriate for a postcondition.

Currently this postcondition is the only remaining bug in the update process that I know of. It fires because tools like the `kio` CLI tool patch application definitions by first fetching all current fields, making local modifications on these fields, and then pushing all of it to the server, which therefore receives a mixture of nil and non-nil fields. The postcondition asserts that there must be no nil fields at all in the result of `created-or-updated-app`, but this conflicts with `sql/cmd-create-or-update-application!` which expects all fields to be present.