### PR TITLE
delivery.yaml: pin Postgres version used in tests

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -12,7 +12,7 @@ pipeline:
   commands:
   - desc: Run unit tests
     cmd: |
-      docker run -d -p 5432:5432 postgres
+      docker run -d -p 5432:5432 postgres:9.6
       lein test
   - desc: Build and push docker image
     cmd: |

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -12,7 +12,7 @@ pipeline:
   commands:
   - desc: Run unit tests
     cmd: |
-      docker run -d -p 5432:5432 postgres:9.6
+      docker run -d -p 5432:5432 postgres:12.1
       lein test
   - desc: Build and push docker image
     cmd: |


### PR DESCRIPTION
This should avoid the "Connection to localhost:5432 refused" error that many Postgres users at Zalando recently reported [(internal link)](https://chat.google.com/room/AAAA_AUoRvk/HwARF-BhicM) after a Postgres update. They were using `:latest`, like Kio does. Changing that to `:9.6`, which is what we run in production.