### PR TITLE
Parametrize :auto-migration? flag

### DIFF
--- a/src/org/zalando/stups/kio/sql.clj
+++ b/src/org/zalando/stups/kio/sql.clj
@@ -13,10 +13,12 @@
 ; limitations under the License.
 
 (ns org.zalando.stups.kio.sql
-  (:require [yesql.core :refer [defqueries]]
+  (:require [environ.core :as  env]
+            [yesql.core :refer [defqueries]]
             [org.zalando.stups.friboo.system.db :refer [def-db-component generate-hystrix-commands]]))
 
-(def-db-component DB :auto-migration? true)
+;;USE env variable AUTO_MIGRATION to configure auto-migration?
+(def-db-component DB :auto-migration? (Boolean/parseBoolean (env/env :auto-migration)))
 
 (def default-db-configuration
   {:db-classname   "org.postgresql.Driver"


### PR DESCRIPTION
Currently, :auto-migration? is always set to true. refs [internal issue](https://github.bus.zalan.do/pitchfork/issues/issues/28)


Load this value from an environment variable instead of hardcoding it