### PR TITLE
feat: update log4j (#132)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,12 @@
   :min-lein-version "2.0.0"
 
   :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.apache.logging.log4j/log4j-api "2.15.0"]
+                 [org.apache.logging.log4j/log4j-core "2.15.0"]
+                 [org.apache.logging.log4j/log4j-slf4j-impl "2.15.0"]
+                 [org.apache.logging.log4j/log4j-jcl "2.15.0"]
+                 [org.apache.logging.log4j/log4j-1.2-api "2.15.0"]
+                 [org.apache.logging.log4j/log4j-jul "2.15.0"]
                  [org.zalando.stups/friboo "1.13.0"]
                  [clj-time "0.13.0"]
                  [org.zalando.stups/tokens "0.11.0-beta-2"]


### PR DESCRIPTION
fixes #132.

Address es 0-day exploit in log4j (see https://www.randori.com/blog/cve-2021-44228/, https://www.lunasec.io/docs/blog/log4j-zero-day)