### PR TITLE
feat: upgrade log4j (#134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kio
 
-[![Build Status](https://travis-ci.org/zalando-stups/kio.svg?branch=master)](https://travis-ci.org/zalando-stups/kio)
+[![Build Status](https://travis-ci.org/zalando-stups/kio.svg?branch=main)](https://travis-ci.org/zalando-stups/kio)
 
 Kio is the application registry in the [STUPS ecosystem](http://zalando-stups.github.io). It manages the basic
 information about an organisation’s applications.

--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,12 @@
   :min-lein-version "2.0.0"
 
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.apache.logging.log4j/log4j-api "2.15.0"]
-                 [org.apache.logging.log4j/log4j-core "2.15.0"]
-                 [org.apache.logging.log4j/log4j-slf4j-impl "2.15.0"]
-                 [org.apache.logging.log4j/log4j-jcl "2.15.0"]
-                 [org.apache.logging.log4j/log4j-1.2-api "2.15.0"]
-                 [org.apache.logging.log4j/log4j-jul "2.15.0"]
+                 [org.apache.logging.log4j/log4j-api "2.16.0"]
+                 [org.apache.logging.log4j/log4j-core "2.16.0"]
+                 [org.apache.logging.log4j/log4j-slf4j-impl "2.16.0"]
+                 [org.apache.logging.log4j/log4j-jcl "2.16.0"]
+                 [org.apache.logging.log4j/log4j-1.2-api "2.16.0"]
+                 [org.apache.logging.log4j/log4j-jul "2.16.0"]
                  [org.zalando.stups/friboo "1.13.0"]
                  [clj-time "0.13.0"]
                  [org.zalando.stups/tokens "0.11.0-beta-2"]


### PR DESCRIPTION
fixes #134.

Fixes the subsequent vulnerability issue of the incomplete log4j fix in `2.15.0` (see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046)

Also finishes the master to main branch renaming.