### PR TITLE
feat: upgrade log4j (#135)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,12 +8,12 @@
   :min-lein-version "2.0.0"
 
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.apache.logging.log4j/log4j-api "2.16.0"]
-                 [org.apache.logging.log4j/log4j-core "2.16.0"]
-                 [org.apache.logging.log4j/log4j-slf4j-impl "2.16.0"]
-                 [org.apache.logging.log4j/log4j-jcl "2.16.0"]
-                 [org.apache.logging.log4j/log4j-1.2-api "2.16.0"]
-                 [org.apache.logging.log4j/log4j-jul "2.16.0"]
+                 [org.apache.logging.log4j/log4j-api "2.17.0"]
+                 [org.apache.logging.log4j/log4j-core "2.17.0"]
+                 [org.apache.logging.log4j/log4j-slf4j-impl "2.17.0"]
+                 [org.apache.logging.log4j/log4j-jcl "2.17.0"]
+                 [org.apache.logging.log4j/log4j-1.2-api "2.17.0"]
+                 [org.apache.logging.log4j/log4j-jul "2.17.0"]
                  [org.zalando.stups/friboo "1.13.0"]
                  [clj-time "0.13.0"]
                  [org.zalando.stups/tokens "0.11.0-beta-2"]


### PR DESCRIPTION
fixes #135.

Upgrade log4j to 2.17.0 to address https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105.