### PR TITLE
Align read-applications returned data to read-application

### DIFF
--- a/resources/api/kio-api.yaml
+++ b/resources/api/kio-api.yaml
@@ -130,6 +130,10 @@ paths:
                   format: date-time
                   description: Point in time when the application was created or last modified.
                   example: '2015-04-25T16:25:00.000Z'
+                last_modified_by:
+                  type: string
+                  description: Who modified the application last
+                  example: npiccolotto
                 matched_rank:
                   type: number
                   description: Search result rank for ordering
@@ -139,6 +143,35 @@ paths:
                 support_url:
                   type: string
                   description: URL Where to contact for support
+                description:
+                  type: string
+                  description: Purpose of this application
+                  example: Kio manages all application base information.
+                required_approvers:
+                  type: integer
+                  description: Minimum number of approvers needed for a version. Used by fullstop. Deprecated, will be removed in the future.
+                  example: 2
+                specification_type:
+                  type: string
+                  description: Where tickets for the application are managed
+                  example: Github
+                created:
+                  type: string
+                  format: date-time
+                  description: Point in time when the application was created.
+                  example: '2015-04-25T16:25:00.000Z'
+                created_by:
+                  type: string
+                  description: Who created the application
+                  example: npiccolotto
+                publicly_accessible:
+                  type: boolean
+                  description: |
+                    Marks an app as "publicly available" (on the internet). A public app usually has a landing or login
+                    page and does not expose confidential data to unauthorized users. Examples are: Blogs, Job Portals,
+                    Shops, and so on. Secured (REST)-APIs and micro services are no public endpoints, even if they are
+                    available over the internet.
+                  example: true
               required:
                 - id
                 - team_id

--- a/resources/db/applications.sql
+++ b/resources/db/applications.sql
@@ -11,7 +11,13 @@ SELECT a_id as id,
        a_scm_url as scm_url,
        a_documentation_url as documentation_url,
        a_specification_url as specification_url,
-       a_last_modified as last_modified
+       a_last_modified as last_modified,
+       a_last_modified_by as last_modified_by,
+       a_description as description,
+       a_specification_type as specification_type,
+       a_created as created,
+       a_created_by as created_by,
+       a_publicly_accessible as publicly_accessible
   FROM zk_data.application
  WHERE a_last_modified <= COALESCE(:modified_before, a_last_modified)
    AND a_last_modified >= COALESCE(:modified_after, a_last_modified)
@@ -33,7 +39,14 @@ FROM (
                 a_scm_url as scm_url,
                 a_documentation_url as documentation_url,
                 a_specification_url as specification_url,
-                a_last_modified as last_modified
+                a_last_modified as last_modified,
+                a_last_modified_by as last_modified_by,
+                a_description as description,
+                a_specification_type as specification_type,
+                a_criticality_level as criticality_level,
+                a_created as created,
+                a_created_by as created_by,
+                a_publicly_accessible as publicly_accessible
          FROM zk_data.application
          WHERE a_last_modified <= COALESCE(:modified_before, a_last_modified)
            AND a_last_modified >= COALESCE(:modified_after, a_last_modified)
@@ -55,6 +68,13 @@ FROM (
          a_documentation_url as documentation_url,
          a_specification_url as specification_url,
          a_last_modified as last_modified,
+         a_last_modified_by as last_modified_by,
+         a_description as description,
+         a_specification_type as specification_type,
+         a_criticality_level as criticality_level,
+         a_created as created,
+         a_created_by as created_by,
+         a_publicly_accessible as publicly_accessible,
          ts_rank_cd(vector, query) AS matched_rank,
          ts_headline('english', a_id || ' ' ||
                                 a_name || ' ' ||
@@ -72,7 +92,13 @@ FROM (
                  a_documentation_url,
                  a_specification_url,
                  a_last_modified,
+                 a_last_modified_by,
                  a_description,
+                 a_specification_type,
+                 a_criticality_level,
+                 a_created,
+                 a_created_by,
+                 a_publicly_accessible,
                  setweight(to_tsvector('english', a_id), 'A')
                  || setweight(to_tsvector('english', a_name), 'B')
                  || setweight(to_tsvector('english', COALESCE(a_subtitle, '')), 'C')

--- a/src/org/zalando/stups/kio/api.clj
+++ b/src/org/zalando/stups/kio/api.clj
@@ -113,11 +113,13 @@
         (-> (if (and (nil? team_id) (nil? incident_contact))
               (read-application-memo params db)
               (sql/cmd-read-applications params conn))
+            (enrich-applications)
             (response)
             (content-type-json)))
       (do
         (log/debug "Search in applications with term %s." search)
         (-> (sql/cmd-search-applications params conn)
+            (enrich-applications)
             (response)
             (content-type-json))))))
 


### PR DESCRIPTION
Aligned read-applications returned data to read-application adding following missing details:
- last_modified_by
- description
- specification_type
- criticality_level (already declared in kio-api.yaml but not returned currently)
- created
- created_by
- publicly_accessible 
- required_approvers