### PR TITLE
[AUTOMATED] Use officially supported openjdk 8 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensource.zalan.do/library/openjdk-8:latest
+FROM container-registry.zalando.net/library/eclipse-temurin-8-jdk:latest
 
 MAINTAINER Zalando SE
 

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -4,7 +4,9 @@ pipeline:
   env:
     LEIN_ROOT: true
   type: script
-  overlay: ci/clojure-for-cdp
+  vm_config:
+    type: linux
+    image: "cdp-runtime/jdk8-clojure"
   artifacts:
   - type: docs
     name: automata-databases


### PR DESCRIPTION
The Container Platform team is in the process of updating the Kubernetes node OS from Ubuntu 20.04 to Ubuntu 22.04.
With the switch to Ubuntu 22.04 in test clusters, it has been discovered that the base image `registry.opensource.zalan.do/library/openjdk-8:latest` is not compatible with Ubuntu 22.04 because of changes from cgroup v1 to cgroup v2 for managing the containers on the nodes.
The issue can be observed as high memory usage and OOMKill for applications running with the legacy base image.

This automated Pull Request updates any use of `registry.opensource.zalan.do/library/openjdk-8:latest` as base image to use the maintained base image version `container-registry.zalando.net/library/eclipse-temurin-8-jdk:latest` which has been confirmed to solve the problem.

Please update the base image by merging this PR and verify that it works as expected. Without this change there is a risk that your application(s) will be OOMKilled when the Kubernetes node OS is updated to Ubuntu 22.04 **beginning of January 2024**.