### PR TITLE
add missing step importing certis into java keystore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN mkdir /tmp/rds-ca && \
 # see http://blog.swwomm.com/2015/02/importing-new-rds-ca-certificate-into.html
 RUN cd /tmp/rds-ca && csplit -sz aws-rds-ca-bundle.pem '/-BEGIN CERTIFICATE-/' '{*}'
 RUN for CERT in /tmp/rds-ca/xx*; do mv $CERT /usr/local/share/ca-certificates/aws-rds-ca-$(basename $CERT).crt; done
+
+# Sample script for importing certificates on Linux to the Java Keystore
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL-certificate-rotation.html#UsingWithRDS.SSL-certificate-rotation-sample-script
+RUN awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ".pem"}' < /tmp/rds-ca/aws-rds-ca-bundle.pem && \
+    for CERT in rds-ca-*; do alias=$(openssl x509 -noout -text -in $CERT | perl -ne 'next unless /Subject:/; s/.*(CN=|CN = )//; print'); keytool -import -file ${CERT} -alias "${alias}" -storepass changeit -keystore $JAVA_HOME/jre/lib/security/cacerts -noprompt; rm ${CERT}; done
+
 RUN update-ca-certificates
 
 COPY resources/api/kio-api.yaml /zalando-apis/


### PR DESCRIPTION
Based on the docs at https://jvm.docs.zalando.net/upgrading_java/index.html#rds-certificates we also need to import the certs to the Java Keystore. This was probably added after the last Kio rollout or not necessary with the old base image.

The section is now identical to https://jvm.docs.zalando.net/upgrading_java/index.html#rds-certificates

follow up to #139 