### PR TITLE
add CDP builds triggered by a docker image dependency

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,4 +1,10 @@
 version: '2017-09-20'
+
+dependencies:
+  - id: java
+    type: docker
+    ref: registry.opensource.zalan.do/library/eclipse-temurin-8-jdk
+
 pipeline:
 - id: build
   env:


### PR DESCRIPTION
Adds dependency-triggered builds for `container-registry.zalando.net/library/eclipse-temurin-8-jdk` Docker image used in Kio. Fixes: [Collibra alert](https://zalando.collibra.com/asset/6f19c73a-5f7c-4b65-9e5e-6879b0fef35c).