### PR TITLE
Migrate CDP docker dependency URL to container-registry

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,7 +3,7 @@ version: '2017-09-20'
 dependencies:
   - id: java
     type: docker
-    ref: registry.opensource.zalan.do/library/eclipse-temurin-8-jdk
+    ref: container-registry.zalando.net/library/eclipse-temurin-8-jdk
 
 pipeline:
 - id: build


### PR DESCRIPTION
Migrate CDP docker dependency URL to container-registry in order to fix the issue with builds not being triggered.

The `container-registry.zalando.net/library/eclipse-temurin-8-jdk` image is already used in [Dockerfile](https://github.com/zalando-stups/kio/blob/main/Dockerfile#L1).