### PR TITLE
chore: Add repo type in Zappr config file

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -11,3 +11,4 @@ approvals:
   ignore: none
   
 X-Zalando-Team: "automata"
+X-Zalando-Type: "code"


### PR DESCRIPTION
Add repository type in Zappr config file required for compliance check by ComPR